### PR TITLE
Fix merge of individual umlaut structures into a single structure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject umlaut "0.4.0"
+(defproject umlaut "0.4.1"
   :description "A Clojure program that receives a schema and outputs code."
   :url "https://github.com/workco/umlaut"
   :license {:name "MIT License"

--- a/src/umlaut/core.clj
+++ b/src/umlaut/core.clj
@@ -4,7 +4,7 @@
             [clojure.spec.test :as stest]
             [umlaut.models :as model]
             [umlaut.parser :refer [parse]]
-            [umlaut.utils :refer [in? map-extend primitive-types]]))
+            [umlaut.utils :refer [in? primitive-types]]))
 
 (defn- read-parse [path]
   "Read all the umlaut files from a folder and parse its content"
@@ -13,8 +13,8 @@
        (flatten)
        (reduce (fn [acc filename]
                  (let [parsed (parse (slurp filename))]
-                   (map-extend acc {:nodes (parsed :nodes)
-                                    :diagrams (parsed :diagrams)}))) {})))
+                   {:nodes (merge (:nodes acc) (:nodes parsed))
+                    :diagrams (merge (:diagrams acc) (:diagrams parsed))})) {})))
 
 (defn- get-all-fields
   [parsed]

--- a/src/umlaut/utils.clj
+++ b/src/umlaut/utils.clj
@@ -36,15 +36,6 @@
   [node]
   (or (type? node) (interface? node) (enum? node)))
 
-(defn map-extend [base extension]
-  (reduce (fn [acc [key value]]
-            (if (contains? acc key)
-              (if (instance? clojure.lang.PersistentArrayMap value)
-                (assoc acc key (map-extend (base key) (extension key)))
-                (assoc acc key value))
-              (assoc acc key value)))
-          base (seq extension)))
-
 (defn seek [func coll]
   "Returns the first occurrence when func is true in coll"
   (first (filter func coll)))

--- a/test/umlaut/utils_test.clj
+++ b/test/umlaut/utils_test.clj
@@ -25,14 +25,6 @@
     (is (type-interface-or-enum? [:interface])))
 
   (testing "Data manipulation"
-    (is (= {:a 3} (map-extend {} {:a 3})))
-    (is (= {:b 1, :a 3} (map-extend {:b 1} {:a 3})))
-    (is (= {:a {:b 1}, :c 4} (map-extend {:a {:b 1}} {:c 4})))
-    (is (= {:a {:b 1}, :c 4} (map-extend {:a {:b 1}} {:c 4})))
-    (is (= {:a {:b 2 :c 4}} (map-extend {:a {:b 1 :c 4}} {:a {:b 2}})))
-    (is (= {:a {:b 2, :c 3}} (map-extend {:a {:b 1}} {:a {:b 2 :c 3}})))
-    (is (= {:a {:b 2, :c 3}, :c 5} (map-extend {:a {:b 1}} {:a {:b 2 :c 3} :c 5})))
-    (is (= {:a {:b {:c {:d 6}}, :h 5}} (map-extend {:a {:b {:c {:d 5}}}} {:a {:b {:c {:d 6}} :h 5}})))
     (is (in? 3 [1 2 3]))
     (is (in? 3 '(1 2 3)))
     (is (in? {} '(1 {} 3)))


### PR DESCRIPTION
Each umlaut file generates an umlaut structure. This structure has a :nodes and a :diagrams key. In the beginning of the execution of an umlaut script, we need to open, parse and merge all the individual umlaut files into a single umlaut structure, which will be the input to the generators. This merge was being done by a custom function, but it could be simply replaced by the built-in merge function.